### PR TITLE
fixing compatibility with ufcc

### DIFF
--- a/prolintpy/core/computecontacts.py
+++ b/prolintpy/core/computecontacts.py
@@ -460,7 +460,7 @@ Indicate for which protein to calculate contacts using the 'protein' option.""")
 
     is_class = n[key1][key2][key3]
 
-    if isinstance(is_class, LPContacts):
+    if hasattr(is_class, contacts):
         for pc in n[protein].keys():
             if contacts == 'contacts':
                 contact = n[protein][pc][r].contacts


### PR DESCRIPTION
Tho make sure that the *export_to_prolint()* method in **ufcc** works, I changed the isintance conditional in the *retrieve_contacts* function to a hasattr conditional. This change does not affect the sense of the conditional, and makes it compatible to work together with **ufcc**.